### PR TITLE
Removing engine_version validation

### DIFF
--- a/optional.tf
+++ b/optional.tf
@@ -62,10 +62,6 @@ variable "engine_version" {
   description = "Engine version of the RDS cluster"
   default     = "14.6" # Use a valid version for Serverless v2
   type        = string
-  validation {
-    condition     = (var.engine_version >= "13.7" && var.engine_version <= "13.7") || (var.engine_version >= "14" && var.engine_version <= "15")
-    error_message = "Ensure the engine version is compatible with Aurora PostgreSQL versions that support Serverless v2 (>= 13.7 or 14.x)."
-  }
 }
 
 variable "engine_preferred_versions" {


### PR DESCRIPTION
The validation we had was only valid for PostgreSQL and as a result prevented MySQL clusters from upgrading to the latest version of this module because their version string is formatted different (8.0.mysql_aurora.3.07.0 for example).

I think it would be pretty tough to validate this field. For your consideration, consider the output of
`aws rds describe-db-engine-versions`. At the time of writing, running this command gives 154 options for mysql and postgres alone. Given that terragrunt apply would catch this for us, I don't think it's really worth trying to validate against so many options.